### PR TITLE
Add shape raycasts and tests

### DIFF
--- a/src/geometry/RaycastShapes.cpp
+++ b/src/geometry/RaycastShapes.cpp
@@ -1,0 +1,344 @@
+#include "geometry/RaycastShapes.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace c2d
+{
+
+std::optional<std::pair<float, float>> raycast(const Circle& circle,
+                                               Transform transform,
+                                               Ray ray)
+{
+    const Vec2 center = transform.apply(circle.center);
+    const Vec2 rayDirection = ray.p2 - ray.p1;
+    const Vec2 fromStartToCenter = ray.p1 - center;
+
+    const float directionLengthSq = rayDirection.dot(rayDirection);
+    const float startProjection = fromStartToCenter.dot(rayDirection);
+    const float startDistanceSq = fromStartToCenter.dot(fromStartToCenter) -
+                                   circle.radius * circle.radius;
+
+    if (directionLengthSq <= 0.0f)
+    {
+        if (startDistanceSq <= 0.0f)
+            return std::make_pair(0.0f, 0.0f);
+        return std::nullopt;
+    }
+
+    if (startDistanceSq > 0.0f && startProjection > 0.0f)
+        return std::nullopt;
+
+    const float discriminant = startProjection * startProjection -
+                               directionLengthSq * startDistanceSq;
+    if (discriminant < 0.0f)
+        return std::nullopt;
+
+    const float root = std::sqrt(discriminant);
+    float entry = (-startProjection - root) / directionLengthSq;
+    float exit = (-startProjection + root) / directionLengthSq;
+
+    if (entry > exit)
+        std::swap(entry, exit);
+
+    if (entry > 1.0f || exit < 0.0f)
+        return std::nullopt;
+
+    entry = std::max(entry, 0.0f);
+    exit = std::min(exit, 1.0f);
+    if (entry > exit)
+        return std::nullopt;
+
+    return std::make_pair(entry, exit);
+}
+
+std::optional<std::pair<float, float>> raycast(const Circle& circle,
+                                               Transform transform,
+                                               InfiniteRay ray)
+{
+    const Vec2 center = transform.apply(circle.center);
+    const Vec2 rayDirection = ray.direction;
+    const Vec2 fromStartToCenter = ray.start - center;
+
+    const float directionLengthSq = rayDirection.dot(rayDirection);
+    const float startProjection = fromStartToCenter.dot(rayDirection);
+    const float startDistanceSq = fromStartToCenter.dot(fromStartToCenter) -
+                                   circle.radius * circle.radius;
+
+    if (directionLengthSq <= 0.0f)
+    {
+        if (startDistanceSq <= 0.0f)
+            return std::make_pair(0.0f, 0.0f);
+        return std::nullopt;
+    }
+
+    if (startDistanceSq > 0.0f && startProjection > 0.0f)
+        return std::nullopt;
+
+    const float discriminant = startProjection * startProjection -
+                               directionLengthSq * startDistanceSq;
+    if (discriminant < 0.0f)
+        return std::nullopt;
+
+    const float root = std::sqrt(discriminant);
+    float entry = (-startProjection - root) / directionLengthSq;
+    float exit = (-startProjection + root) / directionLengthSq;
+
+    if (entry > exit)
+        std::swap(entry, exit);
+    if (exit < 0.0f)
+        return std::nullopt;
+
+    entry = std::max(entry, 0.0f);
+    return std::make_pair(entry, exit);
+}
+
+std::optional<std::pair<float, float>> raycast(const Segment& segment,
+                                               Transform transform,
+                                               Ray ray)
+{
+    const Vec2 point1 = transform.apply(segment.start);
+    const Vec2 point2 = transform.apply(segment.end);
+    const Vec2 segmentVector = point2 - point1;
+    const Vec2 rayVector = ray.p2 - ray.p1;
+    const Vec2 delta = ray.p1 - point1;
+
+    const float crossSegRay = segmentVector.cross(rayVector);
+    const float crossDeltaSeg = delta.cross(segmentVector);
+
+    if (std::abs(crossSegRay) < 1e-8f)
+        return std::nullopt;
+
+    const float tSegment = delta.cross(rayVector) / crossSegRay;
+    const float tRay = crossDeltaSeg / crossSegRay;
+
+    if (tSegment >= 0.0f && tSegment <= 1.0f && tRay >= 0.0f && tRay <= 1.0f)
+        return std::make_pair(tRay, tRay);
+
+    return std::nullopt;
+}
+
+std::optional<std::pair<float, float>> raycast(const Segment& segment,
+                                               Transform transform,
+                                               InfiniteRay ray)
+{
+    const Vec2 point1 = transform.apply(segment.start);
+    const Vec2 point2 = transform.apply(segment.end);
+    const Vec2 segmentVector = point2 - point1;
+    const Vec2 rayVector = ray.direction;
+    const Vec2 delta = ray.start - point1;
+
+    const float crossSegRay = segmentVector.cross(rayVector);
+    const float crossDeltaSeg = delta.cross(segmentVector);
+
+    if (std::abs(crossSegRay) < 1e-8f)
+        return std::nullopt;
+
+    const float tSegment = delta.cross(rayVector) / crossSegRay;
+    const float tRay = crossDeltaSeg / crossSegRay;
+
+    if (tSegment >= 0.0f && tSegment <= 1.0f && tRay >= 0.0f)
+        return std::make_pair(tRay, tRay);
+
+    return std::nullopt;
+}
+
+std::optional<std::pair<float, float>> raycast(const Polygon& polygon,
+                                               Transform transform,
+                                               Ray ray)
+{
+    const Vec2 rayDirection = ray.p2 - ray.p1;
+
+    float lower = 0.0f;
+    float upper = 1.0f;
+    for (uint8_t i = 0; i < polygon.count; ++i)
+    {
+        const Vec2 vertex = transform.apply(polygon.vertices[i]);
+        const Vec2 normal = transform.rotation.apply(polygon.normals[i]);
+        const float numerator = normal.dot(vertex - ray.p1);
+        const float denominator = normal.dot(rayDirection);
+
+        if (std::abs(denominator) < 1e-8f)
+        {
+            if (numerator < 0.0f)
+                return std::nullopt;
+            continue;
+        }
+
+        const float t = numerator / denominator;
+        if (denominator < 0.0f)
+        {
+            lower = std::max(lower, t);
+        }
+        else
+        {
+            upper = std::min(upper, t);
+        }
+        if (upper < lower)
+            return std::nullopt;
+    }
+
+    return std::make_pair(lower, upper);
+}
+
+std::optional<std::pair<float, float>> raycast(const Polygon& polygon,
+                                               Transform transform,
+                                               InfiniteRay ray)
+{
+    const Vec2 rayDirection = ray.direction;
+
+    float lower = 0.0f;
+    float upper = std::numeric_limits<float>::infinity();
+    for (uint8_t i = 0; i < polygon.count; ++i)
+    {
+        const Vec2 vertex = transform.apply(polygon.vertices[i]);
+        const Vec2 normal = transform.rotation.apply(polygon.normals[i]);
+        const float numerator = normal.dot(vertex - ray.start);
+        const float denominator = normal.dot(rayDirection);
+
+        if (std::abs(denominator) < 1e-8f)
+        {
+            if (numerator < 0.0f)
+                return std::nullopt;
+            continue;
+        }
+
+        const float t = numerator / denominator;
+        if (denominator < 0.0f)
+        {
+            lower = std::max(lower, t);
+        }
+        else
+        {
+            upper = std::min(upper, t);
+        }
+        if (upper < lower)
+            return std::nullopt;
+    }
+
+    return std::make_pair(lower, upper);
+}
+
+std::optional<std::pair<float, float>> raycast(const Capsule& capsule,
+                                               Transform transform,
+                                               Ray ray)
+{
+    const Vec2 worldStart = transform.apply(capsule.center1);
+    const Vec2 worldEnd = transform.apply(capsule.center2);
+    const float radius = capsule.radius;
+
+    const Vec2 axis = worldEnd - worldStart;
+    const float length = axis.length();
+    if (length <= 1e-8f)
+    {
+        Circle circle{worldStart, radius};
+        return raycast(circle, Transform{}, ray);
+    }
+    const Vec2 axisUnit = axis * (1.0f / length);
+    const Vec2 side{ -axisUnit.y, axisUnit.x };
+
+    const auto toLocal = [&](Vec2 point) -> Vec2
+    {
+        const Vec2 diff = point - worldStart;
+        return Vec2{ diff.dot(axisUnit), diff.dot(side) };
+    };
+
+    Ray localRay{ toLocal(ray.p1), toLocal(ray.p2) };
+    AABB core{ Vec2{0.0f, -radius}, Vec2{length, radius} };
+
+    float entryTime = std::numeric_limits<float>::infinity();
+    float exitTime = -std::numeric_limits<float>::infinity();
+    bool hit = false;
+
+    auto update = [&](std::optional<std::pair<float, float>> iv)
+    {
+        if (!iv)
+            return;
+        hit = true;
+        entryTime = std::min(entryTime, iv->first);
+        exitTime = std::max(exitTime, iv->second);
+    };
+
+    update(core.intersects(localRay));
+
+    Circle capA{ Vec2{0.0f, 0.0f}, radius };
+    Circle capB{ Vec2{length, 0.0f}, radius };
+    update(raycast(capA, Transform{}, localRay));
+    update(raycast(capB, Transform{}, localRay));
+
+    if (!hit)
+        return std::nullopt;
+
+    if (exitTime < 0.0f || entryTime > 1.0f || exitTime < entryTime)
+        return std::nullopt;
+
+    entryTime = std::max(entryTime, 0.0f);
+    exitTime = std::min(exitTime, 1.0f);
+    if (entryTime > exitTime)
+        return std::nullopt;
+
+    return std::make_pair(entryTime, exitTime);
+}
+
+std::optional<std::pair<float, float>> raycast(const Capsule& capsule,
+                                               Transform transform,
+                                               InfiniteRay ray)
+{
+    const Vec2 worldStart = transform.apply(capsule.center1);
+    const Vec2 worldEnd = transform.apply(capsule.center2);
+    const float radius = capsule.radius;
+
+    const Vec2 axis = worldEnd - worldStart;
+    const float length = axis.length();
+    if (length <= 1e-8f)
+    {
+        Circle circle{worldStart, radius};
+        return raycast(circle, Transform{}, ray);
+    }
+    const Vec2 axisUnit = axis * (1.0f / length);
+    const Vec2 side{ -axisUnit.y, axisUnit.x };
+
+    const auto toLocal = [&](Vec2 point) -> Vec2
+    {
+        const Vec2 diff = point - worldStart;
+        return Vec2{ diff.dot(axisUnit), diff.dot(side) };
+    };
+
+    InfiniteRay localRay{ toLocal(ray.start),
+                          Vec2{ ray.direction.dot(axisUnit),
+                                ray.direction.dot(side) } };
+    AABB core{ Vec2{0.0f, -radius}, Vec2{length, radius} };
+
+    float entryTime = std::numeric_limits<float>::infinity();
+    float exitTime = -std::numeric_limits<float>::infinity();
+    bool hit = false;
+
+    auto update = [&](std::optional<std::pair<float, float>> iv)
+    {
+        if (!iv)
+            return;
+        hit = true;
+        entryTime = std::min(entryTime, iv->first);
+        exitTime = std::max(exitTime, iv->second);
+    };
+
+    update(core.intersects(localRay));
+
+    Circle capA{ Vec2{0.0f, 0.0f}, radius };
+    Circle capB{ Vec2{length, 0.0f}, radius };
+    update(raycast(capA, Transform{}, localRay));
+    update(raycast(capB, Transform{}, localRay));
+
+    if (!hit)
+        return std::nullopt;
+
+    if (exitTime < 0.0f || entryTime > exitTime)
+        return std::nullopt;
+
+    entryTime = std::max(entryTime, 0.0f);
+    return std::make_pair(entryTime, exitTime);
+}
+
+} // namespace c2d
+

--- a/src/geometry/RaycastShapes.hpp
+++ b/src/geometry/RaycastShapes.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <optional>
+#include <utility>
+
+#include "colli2de/Shapes.hpp"
+#include "geometry/Ray.hpp"
+#include "geometry/Transformations.hpp"
+#include "geometry/AABB.hpp"
+
+namespace c2d
+{
+
+std::optional<std::pair<float, float>> raycast(const Circle& circle,
+                                               Transform transform,
+                                               Ray ray);
+
+std::optional<std::pair<float, float>> raycast(const Circle& circle,
+                                               Transform transform,
+                                               InfiniteRay ray);
+
+std::optional<std::pair<float, float>> raycast(const Capsule& capsule,
+                                               Transform transform,
+                                               Ray ray);
+
+std::optional<std::pair<float, float>> raycast(const Capsule& capsule,
+                                               Transform transform,
+                                               InfiniteRay ray);
+
+std::optional<std::pair<float, float>> raycast(const Segment& segment,
+                                               Transform transform,
+                                               Ray ray);
+
+std::optional<std::pair<float, float>> raycast(const Segment& segment,
+                                               Transform transform,
+                                               InfiniteRay ray);
+
+std::optional<std::pair<float, float>> raycast(const Polygon& polygon,
+                                               Transform transform,
+                                               Ray ray);
+
+std::optional<std::pair<float, float>> raycast(const Polygon& polygon,
+                                               Transform transform,
+                                               InfiniteRay ray);
+
+} // namespace c2d

--- a/tests/geometry/test_RaycastShapes.cpp
+++ b/tests/geometry/test_RaycastShapes.cpp
@@ -1,0 +1,101 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "geometry/RaycastShapes.hpp"
+#include "geometry/AABB.hpp"
+
+using namespace c2d;
+using namespace Catch;
+
+TEST_CASE("Circle raycast basic hits", "[Raycast][Circle]")
+{
+    Circle circle{ Vec2{1.0f, 1.0f}, 1.0f };
+    Ray ray{ Vec2{-2.0f, 1.0f}, Vec2{4.0f, 1.0f} };
+
+    const auto result = raycast(circle, Transform{}, ray);
+    REQUIRE(result);
+    auto [entry, exit] = *result;
+    CHECK(entry == Approx(1.0f/3.0f));
+    CHECK(exit == Approx(2.0f/3.0f));
+}
+
+TEST_CASE("Circle raycast starting inside", "[Raycast][Circle]")
+{
+    Circle circle{ Vec2{0.0f, 0.0f}, 1.0f };
+    Ray ray{ Vec2{0.0f, 0.0f}, Vec2{2.0f, 0.0f} };
+
+    const auto result = raycast(circle, Transform{}, ray);
+    REQUIRE(result);
+    auto [entry, exit] = *result;
+    CHECK(entry == Approx(0.0f));
+    CHECK(exit == Approx(0.5f));
+}
+
+TEST_CASE("Circle infinite ray miss", "[Raycast][Circle]")
+{
+    Circle circle{ Vec2{0.0f, 0.0f}, 1.0f };
+    InfiniteRay ray{ Vec2{0.0f, 2.0f}, Vec2{1.0f, 0.0f} };
+    REQUIRE_FALSE(raycast(circle, Transform{}, ray));
+}
+
+TEST_CASE("Segment finite ray hit", "[Raycast][Segment]")
+{
+    Segment seg{ Vec2{1.0f, 1.0f}, Vec2{3.0f, 1.0f} };
+    Ray ray{ Vec2{2.0f, 0.0f}, Vec2{2.0f, 2.0f} };
+
+    const auto result = raycast(seg, Transform{}, ray);
+    REQUIRE(result);
+    CHECK(result->first == Approx(0.5f));
+    CHECK(result->second == Approx(0.5f));
+}
+
+TEST_CASE("Segment parallel miss", "[Raycast][Segment]")
+{
+    Segment seg{ Vec2{0.0f, 1.0f}, Vec2{3.0f, 1.0f} };
+    Ray ray{ Vec2{0.0f, 2.0f}, Vec2{3.0f, 2.0f} };
+    REQUIRE_FALSE(raycast(seg, Transform{}, ray));
+}
+
+TEST_CASE("Polygon raycast through square", "[Raycast][Polygon]")
+{
+    Polygon poly = makeRectangle(Vec2{1.0f, 1.0f}, 1.0f, 1.0f);
+    Ray ray{ Vec2{-1.0f, 1.0f}, Vec2{3.0f, 1.0f} };
+
+    const auto result = raycast(poly, Transform{}, ray);
+    REQUIRE(result);
+    auto [entry, exit] = *result;
+    CHECK(entry == Approx(0.25f));
+    CHECK(exit == Approx(0.75f));
+}
+
+TEST_CASE("Polygon infinite ray starting inside", "[Raycast][Polygon]")
+{
+    std::array<Vec2,3> verts{ Vec2{0,0}, Vec2{2,0}, Vec2{1,2} };
+    Polygon tri{ verts, 3, 0.0f };
+    InfiniteRay ray{ Vec2{1.0f, 1.0f}, Vec2{0.0f, 1.0f} };
+
+    const auto result = raycast(tri, Transform{}, ray);
+    REQUIRE(result);
+    CHECK(result->first == Approx(0.0f));
+    CHECK(result->second > 0.0f);
+}
+
+TEST_CASE("Capsule raycast through body", "[Raycast][Capsule]")
+{
+    Capsule cap{ Vec2{0.0f, 0.0f}, Vec2{4.0f, 0.0f}, 1.0f };
+    Ray ray{ Vec2{-2.0f, 0.0f}, Vec2{6.0f, 0.0f} };
+
+    const auto result = raycast(cap, Transform{}, ray);
+    REQUIRE(result);
+    auto [entry, exit] = *result;
+    CHECK(entry == Approx(0.125f));
+    CHECK(exit == Approx(0.875f));
+}
+
+TEST_CASE("Capsule infinite ray miss", "[Raycast][Capsule]")
+{
+    Capsule cap{ Vec2{0.0f,0.0f}, Vec2{4.0f,0.0f}, 1.0f };
+    InfiniteRay ray{ Vec2{0.0f,3.0f}, Vec2{1.0f,0.0f} };
+    REQUIRE_FALSE(raycast(cap, Transform{}, ray));
+}
+

--- a/tests/geometry/test_RaycastShapes_performance.cpp
+++ b/tests/geometry/test_RaycastShapes_performance.cpp
@@ -1,0 +1,188 @@
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/benchmark/catch_benchmark.hpp>
+
+#include "geometry/RaycastShapes.hpp"
+#include "utils/Random.hpp"
+
+using namespace c2d;
+using namespace Catch;
+using namespace std::chrono;
+
+TEST_CASE("Raycast performance: Circle", "[Raycast][Benchmark][Circle]")
+{
+#ifndef NDEBUG
+    SKIP("Performance test skipped in Debug mode.");
+#endif
+
+    const auto seed = Catch::getCurrentContext().getConfig()->rngSeed();
+    microseconds elapsed;
+    auto circles = generateRandomCircles(100'000, -50.0f, 50.0f, 1.0f, seed);
+    auto rays = generateRandomRays(100'000, -60.0f, 60.0f, seed + 1);
+
+    BENCHMARK("Raycast 10k circles")
+    {
+        const auto start = high_resolution_clock::now();
+        uint32_t total = 0;
+        for (uint32_t i = 0; i < 10'000; ++i)
+        {
+            if (raycast(circles[i], Transform{}, rays[i]))
+                ++total;
+        }
+        const auto end = high_resolution_clock::now();
+        elapsed = duration_cast<microseconds>(end - start);
+        return total;
+    };
+    CHECK(elapsed < 500us);
+    std::cout << std::endl << duration_cast<microseconds>(elapsed).count() << "us/500us" << std::endl;
+
+    BENCHMARK("Raycast 100k circles")
+    {
+        const auto start = high_resolution_clock::now();
+        uint32_t total = 0;
+        for (uint32_t i = 0; i < 100'000; ++i)
+        {
+            if (raycast(circles[i], Transform{}, rays[i]))
+                ++total;
+        }
+        const auto end = high_resolution_clock::now();
+        elapsed = duration_cast<microseconds>(end - start);
+        return total;
+    };
+    CHECK(elapsed < 5000us);
+    std::cout << std::endl << duration_cast<microseconds>(elapsed).count() << "us/5000us" << std::endl;
+}
+
+TEST_CASE("Raycast performance: Segment", "[Raycast][Benchmark][Segment]")
+{
+#ifndef NDEBUG
+    SKIP("Performance test skipped in Debug mode.");
+#endif
+
+    const auto seed = Catch::getCurrentContext().getConfig()->rngSeed();
+    microseconds elapsed;
+    auto segments = generateRandomSegments(100'000, -50.0f, 50.0f, 4.0f, seed);
+    auto rays = generateRandomRays(100'000, -60.0f, 60.0f, seed + 1);
+
+    BENCHMARK("Raycast 10k segments")
+    {
+        const auto start = high_resolution_clock::now();
+        uint32_t total = 0;
+        for (uint32_t i = 0; i < 10'000; ++i)
+        {
+            if (raycast(segments[i], Transform{}, rays[i]))
+                ++total;
+        }
+        const auto end = high_resolution_clock::now();
+        elapsed = duration_cast<microseconds>(end - start);
+        return total;
+    };
+    CHECK(elapsed < 500us);
+    std::cout << std::endl << duration_cast<microseconds>(elapsed).count() << "us/500us" << std::endl;
+
+    BENCHMARK("Raycast 100k segments")
+    {
+        const auto start = high_resolution_clock::now();
+        uint32_t total = 0;
+        for (uint32_t i = 0; i < 100'000; ++i)
+        {
+            if (raycast(segments[i], Transform{}, rays[i]))
+                ++total;
+        }
+        const auto end = high_resolution_clock::now();
+        elapsed = duration_cast<microseconds>(end - start);
+        return total;
+    };
+    CHECK(elapsed < 5000us);
+    std::cout << std::endl << duration_cast<microseconds>(elapsed).count() << "us/5000us" << std::endl;
+}
+
+TEST_CASE("Raycast performance: Capsule", "[Raycast][Benchmark][Capsule]")
+{
+#ifndef NDEBUG
+    SKIP("Performance test skipped in Debug mode.");
+#endif
+
+    const auto seed = Catch::getCurrentContext().getConfig()->rngSeed();
+    microseconds elapsed;
+    auto capsules = generateRandomCapsules(100'000, -50.0f, 50.0f, 4.0f, 1.0f, seed);
+    auto rays = generateRandomRays(100'000, -60.0f, 60.0f, seed + 1);
+
+    BENCHMARK("Raycast 10k capsules")
+    {
+        const auto start = high_resolution_clock::now();
+        uint32_t total = 0;
+        for (uint32_t i = 0; i < 10'000; ++i)
+        {
+            if (raycast(capsules[i], Transform{}, rays[i]))
+                ++total;
+        }
+        const auto end = high_resolution_clock::now();
+        elapsed = duration_cast<microseconds>(end - start);
+        return total;
+    };
+    CHECK(elapsed < 1000us);
+    std::cout << std::endl << duration_cast<microseconds>(elapsed).count() << "us/1000us" << std::endl;
+
+    BENCHMARK("Raycast 100k capsules")
+    {
+        const auto start = high_resolution_clock::now();
+        uint32_t total = 0;
+        for (uint32_t i = 0; i < 100'000; ++i)
+        {
+            if (raycast(capsules[i], Transform{}, rays[i]))
+                ++total;
+        }
+        const auto end = high_resolution_clock::now();
+        elapsed = duration_cast<microseconds>(end - start);
+        return total;
+    };
+    CHECK(elapsed < 10000us);
+    std::cout << std::endl << duration_cast<microseconds>(elapsed).count() << "us/10000us" << std::endl;
+}
+
+TEST_CASE("Raycast performance: Polygon", "[Raycast][Benchmark][Polygon]")
+{
+#ifndef NDEBUG
+    SKIP("Performance test skipped in Debug mode.");
+#endif
+
+    const auto seed = Catch::getCurrentContext().getConfig()->rngSeed();
+    microseconds elapsed;
+    auto polygons = generateRandomRectangles(100'000, -50.0f, 50.0f, 0.5f, seed);
+    auto rays = generateRandomRays(100'000, -60.0f, 60.0f, seed + 1);
+
+    BENCHMARK("Raycast 10k polygons")
+    {
+        const auto start = high_resolution_clock::now();
+        uint32_t total = 0;
+        for (uint32_t i = 0; i < 10'000; ++i)
+        {
+            if (raycast(polygons[i], Transform{}, rays[i]))
+                ++total;
+        }
+        const auto end = high_resolution_clock::now();
+        elapsed = duration_cast<microseconds>(end - start);
+        return total;
+    };
+    CHECK(elapsed < 500us);
+    std::cout << std::endl << duration_cast<microseconds>(elapsed).count() << "us/500us" << std::endl;
+
+    BENCHMARK("Raycast 100k polygons")
+    {
+        const auto start = high_resolution_clock::now();
+        uint32_t total = 0;
+        for (uint32_t i = 0; i < 100'000; ++i)
+        {
+            if (raycast(polygons[i], Transform{}, rays[i]))
+                ++total;
+        }
+        const auto end = high_resolution_clock::now();
+        elapsed = duration_cast<microseconds>(end - start);
+        return total;
+    };
+    CHECK(elapsed < 5000us);
+    std::cout << std::endl << duration_cast<microseconds>(elapsed).count() << "us/5000us" << std::endl;
+}

--- a/tests/utils/Random.hpp
+++ b/tests/utils/Random.hpp
@@ -7,6 +7,7 @@
 #include "colli2de/Vec2.hpp"
 #include "colli2de/Shapes.hpp"
 #include "geometry/AABB.hpp"
+#include "geometry/Ray.hpp"
 
 using namespace c2d;
 
@@ -118,4 +119,37 @@ inline std::vector<Polygon> generateRandomRectangles(size_t count, float regionM
     }
 
     return polygons;
+}
+
+inline std::vector<Ray> generateRandomRays(size_t count, float regionMin, float regionMax, uint32_t seed = 42)
+{
+    DeterministicRNG rng(seed);
+    std::vector<Ray> rays;
+    rays.reserve(count);
+
+    for (size_t i = 0; i < count; ++i)
+    {
+        Vec2 start{rng.nextFloat(regionMin, regionMax), rng.nextFloat(regionMin, regionMax)};
+        Vec2 end{rng.nextFloat(regionMin, regionMax), rng.nextFloat(regionMin, regionMax)};
+        rays.push_back(Ray{start, end});
+    }
+
+    return rays;
+}
+
+inline std::vector<InfiniteRay> generateRandomInfiniteRays(size_t count, float regionMin, float regionMax, uint32_t seed = 42)
+{
+    DeterministicRNG rng(seed);
+    std::vector<InfiniteRay> rays;
+    rays.reserve(count);
+
+    for (size_t i = 0; i < count; ++i)
+    {
+        Vec2 start{rng.nextFloat(regionMin, regionMax), rng.nextFloat(regionMin, regionMax)};
+        float angle = rng.nextFloat(0.0f, 2.0f * PI);
+        Vec2 direction{std::cos(angle), std::sin(angle)};
+        rays.push_back(InfiniteRay{start, direction});
+    }
+
+    return rays;
 }


### PR DESCRIPTION
## Summary
- split RaycastShapes into header and implementation file
- implement raycast algorithms for circle, capsule, segment and polygon
- provide extensive unit tests for all shape raycasts
- add performance benchmarks for raycast functions and random ray generators

## Testing
- `./test.sh --cmake -b -r "~[Benchmark]"`
- `./test.sh -r "[Benchmark]"`


------
https://chatgpt.com/codex/tasks/task_e_6861422a10d08328ba07b14aa99cd233