### PR TITLE
Add polygon sweep benchmark and manifold assertions

### DIFF
--- a/src/geometry/SweepShapes.hpp
+++ b/src/geometry/SweepShapes.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <optional>
+
+#include "colli2de/Shapes.hpp"
+#include "colli2de/Vec2.hpp"
+#include "geometry/Transformations.hpp"
+#include "collision/Collision.hpp"
+#include <cmath>
+
+namespace c2d
+{
+
+struct SweepHit
+{
+    float fraction{};
+    Manifold manifold{};
+};
+
+template <typename ShapeA, typename ShapeB>
+std::optional<SweepHit> sweep(const ShapeA& movingShape,
+                              Transform startTransform,
+                              Vec2 translation,
+                              Rotation endRotation,
+                              const ShapeB& targetShape,
+                              Transform targetTransform)
+{
+    const float startAngle = std::atan2(startTransform.rotation.sin, startTransform.rotation.cos);
+    const float endAngle = std::atan2(endRotation.sin, endRotation.cos);
+
+    auto manifoldAt = [&](float fraction) -> Manifold
+    {
+        Transform currentTransform;
+        currentTransform.translation = startTransform.translation + translation * fraction;
+        const float currentAngle = startAngle + (endAngle - startAngle) * fraction;
+        currentTransform.rotation = Rotation{currentAngle};
+        return collide(movingShape, currentTransform, targetShape, targetTransform);
+    };
+
+    Manifold initialManifold = manifoldAt(0.0f);
+    if (initialManifold.pointCount > 0)
+        return SweepHit{0.0f, initialManifold};
+
+    const int32_t coarseSteps = 8;
+    const int32_t refinementSteps = 10;
+    float fractionLower = 0.0f;
+    float fractionUpper = 1.0f;
+    Manifold hitManifold{};
+
+    for (int32_t stepIndex = 1; stepIndex <= coarseSteps; ++stepIndex)
+    {
+        const float testFraction = static_cast<float>(stepIndex) / static_cast<float>(coarseSteps);
+        Manifold testManifold = manifoldAt(testFraction);
+        if (testManifold.pointCount > 0)
+        {
+            fractionLower = static_cast<float>(stepIndex - 1) / static_cast<float>(coarseSteps);
+            fractionUpper = testFraction;
+            hitManifold = testManifold;
+            break;
+        }
+
+        if (stepIndex == coarseSteps)
+            return std::nullopt;
+    }
+
+    for (int32_t iteration = 0; iteration < refinementSteps; ++iteration)
+    {
+        const float midFraction = 0.5f * (fractionLower + fractionUpper);
+        Manifold midManifold = manifoldAt(midFraction);
+        if (midManifold.pointCount > 0)
+        {
+            fractionUpper = midFraction;
+            hitManifold = midManifold;
+        }
+        else
+        {
+            fractionLower = midFraction;
+        }
+    }
+
+    return SweepHit{fractionUpper, hitManifold};
+}
+
+} // namespace c2d
+

--- a/tests/geometry/test_SweepShapes.cpp
+++ b/tests/geometry/test_SweepShapes.cpp
@@ -1,0 +1,169 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "geometry/SweepShapes.hpp"
+
+using namespace c2d;
+using namespace Catch;
+
+TEST_CASE("Circle sweep hits stationary circle", "[Sweep][Circle]")
+{
+    Circle moving{ Vec2{ -2.0f, 0.0f }, 1.0f };
+    Circle target{ Vec2{ 1.0f, 0.0f }, 1.0f };
+    const Vec2 translation{ 4.0f, 0.0f };
+
+    const auto result = sweep(moving, Transform{}, translation, Rotation{}, target, Transform{});
+    REQUIRE(result);
+    CHECK(result->fraction == Approx(0.25f));
+    REQUIRE(result->manifold.pointCount == 1);
+    CHECK(result->manifold.normal.x == Approx(1.0f).margin(0.001f));
+    CHECK(result->manifold.normal.y == Approx(0.0f).margin(0.001f));
+    CHECK(result->manifold.points[0].point == Vec2{ 0.0f, 0.0f });
+    CHECK(result->manifold.points[0].separation == Approx(0.0f).margin(0.001f));
+}
+
+TEST_CASE("Circle sweep starting overlapped", "[Sweep][Circle]")
+{
+    Circle moving{ Vec2{ 0.0f, 0.0f }, 1.0f };
+    Circle target{ Vec2{ 1.0f, 0.0f }, 1.0f };
+    const Vec2 translation{ 2.0f, 0.0f };
+
+    const auto result = sweep(moving, Transform{}, translation, Rotation{}, target, Transform{});
+    REQUIRE(result);
+    CHECK(result->fraction == Approx(0.0f));
+    REQUIRE(result->manifold.pointCount == 1);
+    CHECK(result->manifold.normal.x == Approx(1.0f).margin(0.001f));
+    CHECK(result->manifold.normal.y == Approx(0.0f).margin(0.001f));
+    CHECK(result->manifold.points[0].separation < 0.0f);
+}
+
+TEST_CASE("Circle sweep misses target", "[Sweep][Circle]")
+{
+    Circle moving{ Vec2{ -2.0f, 0.0f }, 1.0f };
+    Circle target{ Vec2{ 1.0f, 0.0f }, 1.0f };
+    const Vec2 translation{ -3.0f, 0.0f };
+
+    const auto result = sweep(moving, Transform{}, translation, Rotation{}, target, Transform{});
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("Circle sweep vertical motion hits target", "[Sweep][Circle]")
+{
+    Circle moving{ Vec2{ 0.0f, -2.0f }, 1.0f };
+    Circle target{ Vec2{ 0.0f, 1.0f }, 1.0f };
+    const Vec2 translation{ 0.0f, 4.0f };
+
+    const auto result = sweep(moving, Transform{}, translation, Rotation{}, target, Transform{});
+    REQUIRE(result);
+    CHECK(result->fraction == Approx(0.25f));
+    REQUIRE(result->manifold.pointCount == 1);
+    CHECK(result->manifold.normal.x == Approx(0.0f).margin(0.001f));
+    CHECK(result->manifold.normal.y == Approx(1.0f).margin(0.001f));
+    CHECK(result->manifold.points[0].point == Vec2{ 0.0f, 0.0f });
+    CHECK(result->manifold.points[0].separation == Approx(0.0f).margin(0.001f));
+}
+
+TEST_CASE("Circle sweep diagonal motion hits target", "[Sweep][Circle]")
+{
+    Circle moving{ Vec2{ -3.0f, -3.0f }, 1.0f };
+    Circle target{ Vec2{ 0.0f, 0.0f }, 1.0f };
+    const Vec2 translation{ 4.0f, 4.0f };
+
+    const auto result = sweep(moving, Transform{}, translation, Rotation{}, target, Transform{});
+    REQUIRE(result);
+    CHECK(result->fraction == Approx(0.3964f).margin(0.001f));
+    REQUIRE(result->manifold.pointCount == 1);
+    CHECK(result->manifold.normal.x == Approx(std::sqrt(0.5f)).margin(0.001f));
+    CHECK(result->manifold.normal.y == Approx(std::sqrt(0.5f)).margin(0.001f));
+    CHECK(result->manifold.points[0].separation == Approx(0.0f).margin(0.001f));
+}
+
+TEST_CASE("Circle sweep with zero translation and separation", "[Sweep][Circle]")
+{
+    Circle moving{ Vec2{ -2.0f, 0.0f }, 1.0f };
+    Circle target{ Vec2{ 1.0f, 0.0f }, 1.0f };
+    const Vec2 translation{ 0.0f, 0.0f };
+
+    const auto result = sweep(moving, Transform{}, translation, Rotation{}, target, Transform{});
+    CHECK_FALSE(result);
+}
+
+TEST_CASE("Circle sweep rotates while moving", "[Sweep][Circle]")
+{
+    Circle moving{ Vec2{ -2.0f, 0.0f }, 1.0f };
+    Circle target{ Vec2{ 1.0f, 0.0f }, 1.0f };
+    const Vec2 translation{ 4.0f, 0.0f };
+    const Rotation endRotation{ static_cast<float>(PI) };
+
+    const auto result = sweep(moving, Transform{}, translation, endRotation, target, Transform{});
+    REQUIRE(result);
+    CHECK(result->fraction == Approx(0.25f));
+    REQUIRE(result->manifold.pointCount == 1);
+    CHECK(result->manifold.normal.x == Approx(std::sqrt(0.5f)).margin(0.001f));
+    CHECK(result->manifold.normal.y == Approx(-std::sqrt(0.5f)).margin(0.001f));
+}
+
+TEST_CASE("Circle sweep zero translation while overlapping", "[Sweep][Circle]")
+{
+    Circle moving{ Vec2{ 0.0f, 0.0f }, 1.0f };
+    Circle target{ Vec2{ 1.0f, 0.0f }, 1.0f };
+    const Vec2 translation{ 0.0f, 0.0f };
+
+    const auto result = sweep(moving, Transform{}, translation, Rotation{}, target, Transform{});
+    REQUIRE(result);
+    CHECK(result->fraction == Approx(0.0f));
+    REQUIRE(result->manifold.pointCount == 1);
+    CHECK(result->manifold.normal.x == Approx(1.0f).margin(0.001f));
+    CHECK(result->manifold.normal.y == Approx(0.0f).margin(0.001f));
+    CHECK(result->manifold.points[0].separation < 0.0f);
+}
+
+TEST_CASE("Circle sweep hits capsule", "[Sweep][Circle][Capsule]")
+{
+    Circle moving{ Vec2{ 0.0f, 0.0f }, 0.5f };
+    Capsule target{ Vec2{ 2.0f, -1.0f }, Vec2{ 2.0f, 1.0f }, 0.5f };
+    const Vec2 translation{ 2.0f, 0.0f };
+
+    const auto result = sweep(moving, Transform{}, translation, Rotation{}, target, Transform{});
+    REQUIRE(result);
+    CHECK(result->fraction == Approx(0.5f));
+    REQUIRE(result->manifold.pointCount == 1);
+    CHECK(result->manifold.normal.x == Approx(1.0f).margin(0.001f));
+    CHECK(result->manifold.normal.y == Approx(0.0f).margin(0.001f));
+    CHECK(result->manifold.points[0].point == Vec2{ 1.5f, 0.0f });
+    CHECK(result->manifold.points[0].separation == Approx(0.0f).margin(0.001f));
+}
+
+TEST_CASE("Capsule sweep hits circle", "[Sweep][Circle][Capsule]")
+{
+    Capsule moving{ Vec2{ -2.0f, -1.0f }, Vec2{ -2.0f, 1.0f }, 0.5f };
+    Circle target{ Vec2{ 1.0f, 0.0f }, 0.5f };
+    const Vec2 translation{ 4.0f, 0.0f };
+
+    const auto result = sweep(moving, Transform{}, translation, Rotation{}, target, Transform{});
+    REQUIRE(result);
+    CHECK(result->fraction == Approx(0.5f));
+    REQUIRE(result->manifold.pointCount == 1);
+    CHECK(result->manifold.normal.x == Approx(1.0f).margin(0.001f));
+    CHECK(result->manifold.normal.y == Approx(0.0f).margin(0.001f));
+    CHECK(result->manifold.points[0].point == Vec2{ 0.5f, 0.0f });
+    CHECK(result->manifold.points[0].separation == Approx(0.0f).margin(0.001f));
+}
+
+TEST_CASE("Circle sweep hits rectangle", "[Sweep][Circle][Polygon]")
+{
+    Circle moving{ Vec2{ -2.0f, 0.0f }, 0.5f };
+    Polygon target = makeRectangle(Vec2{ 0.0f, 0.0f }, 1.0f, 1.0f);
+    const Vec2 translation{ 3.0f, 0.0f };
+
+    const auto result = sweep(moving, Transform{}, translation, Rotation{}, target, Transform{});
+    REQUIRE(result);
+    CHECK(result->fraction == Approx(1.0f / 6.0f).margin(0.001f));
+    REQUIRE(result->manifold.pointCount == 1);
+    CHECK(result->manifold.normal.x == Approx(1.0f).margin(0.001f));
+    CHECK(result->manifold.normal.y == Approx(0.0f).margin(0.001f));
+    CHECK(result->manifold.points[0].point.x == Approx(-1.0f).margin(0.001f));
+    CHECK(result->manifold.points[0].point.y == Approx(0.0f).margin(0.001f));
+    CHECK(result->manifold.points[0].separation == Approx(0.0f).margin(0.001f));
+}
+

--- a/tests/geometry/test_SweepShapes_performance.cpp
+++ b/tests/geometry/test_SweepShapes_performance.cpp
@@ -1,0 +1,102 @@
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/benchmark/catch_benchmark.hpp>
+
+#include "geometry/SweepShapes.hpp"
+#include "utils/Random.hpp"
+
+using namespace c2d;
+using namespace Catch;
+using namespace std::chrono;
+
+TEST_CASE("Sweep performance: Circle vs Circle", "[Sweep][Benchmark][Circle]")
+{
+#ifndef NDEBUG
+    SKIP("Performance test skipped in Debug mode.");
+#endif
+
+    const auto seed = Catch::getCurrentContext().getConfig()->rngSeed();
+    microseconds elapsed;
+    auto moving = generateRandomCircles(100'000, -50.0f, 50.0f, 1.0f, seed);
+    auto targets = generateRandomCircles(100'000, -50.0f, 50.0f, 1.0f, seed + 1);
+    auto translations = generateRandomTranslations(100'000, -5.0f, 5.0f, seed + 2);
+
+    BENCHMARK("Sweep 10k circle pairs")
+    {
+        const auto start = high_resolution_clock::now();
+        uint32_t total = 0;
+        for (uint32_t i = 0; i < 10'000; ++i)
+        {
+            if (sweep(moving[i], Transform{}, translations[i], Rotation{}, targets[i], Transform{}))
+                ++total;
+        }
+        const auto end = high_resolution_clock::now();
+        elapsed = duration_cast<microseconds>(end - start);
+        return total;
+    };
+    CHECK(elapsed < 1200us);
+    std::cout << std::endl << duration_cast<microseconds>(elapsed).count() << "us/1200us" << std::endl;
+
+    BENCHMARK("Sweep 100k circle pairs")
+    {
+        const auto start = high_resolution_clock::now();
+        uint32_t total = 0;
+        for (uint32_t i = 0; i < 100'000; ++i)
+        {
+            if (sweep(moving[i], Transform{}, translations[i], Rotation{}, targets[i], Transform{}))
+                ++total;
+        }
+        const auto end = high_resolution_clock::now();
+        elapsed = duration_cast<microseconds>(end - start);
+        return total;
+    };
+    CHECK(elapsed < 15000us);
+    std::cout << std::endl << duration_cast<microseconds>(elapsed).count() << "us/15000us" << std::endl;
+}
+
+TEST_CASE("Sweep performance: Polygon vs Polygon", "[Sweep][Benchmark][Polygon]")
+{
+#ifndef NDEBUG
+    SKIP("Performance test skipped in Debug mode.");
+#endif
+
+    const auto seed = Catch::getCurrentContext().getConfig()->rngSeed();
+    microseconds elapsed;
+    auto moving = generateRandomRectangles(100'000, -50.0f, 50.0f, 0.5f, seed);
+    auto targets = generateRandomRectangles(100'000, -50.0f, 50.0f, 0.5f, seed + 1);
+    auto translations = generateRandomTranslations(100'000, -5.0f, 5.0f, seed + 2);
+
+    BENCHMARK("Sweep 10k polygon pairs")
+    {
+        const auto start = high_resolution_clock::now();
+        uint32_t total = 0;
+        for (uint32_t i = 0; i < 10'000; ++i)
+        {
+            if (sweep(moving[i], Transform{}, translations[i], Rotation{}, targets[i], Transform{}))
+                ++total;
+        }
+        const auto end = high_resolution_clock::now();
+        elapsed = duration_cast<microseconds>(end - start);
+        return total;
+    };
+    CHECK(elapsed < 10000us);
+    std::cout << std::endl << duration_cast<microseconds>(elapsed).count() << "us/10000us" << std::endl;
+
+    BENCHMARK("Sweep 100k polygon pairs")
+    {
+        const auto start = high_resolution_clock::now();
+        uint32_t total = 0;
+        for (uint32_t i = 0; i < 100'000; ++i)
+        {
+            if (sweep(moving[i], Transform{}, translations[i], Rotation{}, targets[i], Transform{}))
+                ++total;
+        }
+        const auto end = high_resolution_clock::now();
+        elapsed = duration_cast<microseconds>(end - start);
+        return total;
+    };
+    CHECK(elapsed < 50000us);
+    std::cout << std::endl << duration_cast<microseconds>(elapsed).count() << "us/50000us" << std::endl;
+}

--- a/tests/utils/Random.hpp
+++ b/tests/utils/Random.hpp
@@ -153,3 +153,17 @@ inline std::vector<InfiniteRay> generateRandomInfiniteRays(size_t count, float r
 
     return rays;
 }
+
+inline std::vector<Vec2> generateRandomTranslations(size_t count, float minValue, float maxValue, uint32_t seed = 42)
+{
+    DeterministicRNG rng(seed);
+    std::vector<Vec2> translations;
+    translations.reserve(count);
+
+    for (size_t i = 0; i < count; ++i)
+    {
+        translations.push_back(Vec2{ rng.nextFloat(minValue, maxValue), rng.nextFloat(minValue, maxValue) });
+    }
+
+    return translations;
+}


### PR DESCRIPTION
## Summary
- check manifold contents in sweep unit tests
- benchmark polygon vs polygon sweep
- adjust benchmark thresholds and specify manifold normal components

## Testing
- `./test.sh --cmake -b -r "[Sweep]" "~[Benchmark]"`
- `./test.sh --cmake -b -r "[Sweep][Benchmark]"`

------
https://chatgpt.com/codex/tasks/task_e_686153ad26788328847046e0be605081