### PR TITLE
Implement shape queries

### DIFF
--- a/src/geometry/ShapesComputations.hpp
+++ b/src/geometry/ShapesComputations.hpp
@@ -68,4 +68,186 @@ inline AABB computeAABB(const Polygon& polygon, const Transform& transform)
     return AABB{minVertex, maxVertex};
 }
 
+// --- Point containment ---
+inline bool containsPoint(const Circle& circle, Transform transform, Vec2 point)
+{
+    const Vec2 center = transform.apply(circle.center);
+    const Vec2 delta = point - center;
+    return delta.lengthSqr() <= circle.radius * circle.radius;
+}
+
+inline bool containsPoint(const Capsule& capsule, Transform transform, Vec2 point)
+{
+    const Vec2 worldStart = transform.apply(capsule.center1);
+    const Vec2 worldEnd = transform.apply(capsule.center2);
+    const Vec2 segment = worldEnd - worldStart;
+    const float lengthSqr = segment.lengthSqr();
+    float projection = 0.0f;
+    if (lengthSqr > 0.0f)
+        projection = std::clamp((point - worldStart).dot(segment) / lengthSqr, 0.0f, 1.0f);
+    const Vec2 closest = worldStart + segment * projection;
+    const Vec2 delta = point - closest;
+    return delta.lengthSqr() <= capsule.radius * capsule.radius;
+}
+
+inline bool containsPoint(const Segment& segment, Transform transform, Vec2 point)
+{
+    const Vec2 worldStart = transform.apply(segment.start);
+    const Vec2 worldEnd = transform.apply(segment.end);
+    const Vec2 edge = worldEnd - worldStart;
+    const float lengthSqr = edge.lengthSqr();
+    if (lengthSqr == 0.0f)
+        return (point - worldStart).lengthSqr() <= 1e-6f;
+    const float t = std::clamp((point - worldStart).dot(edge) / lengthSqr, 0.0f, 1.0f);
+    const Vec2 closest = worldStart + edge * t;
+    return (point - closest).lengthSqr() <= 1e-6f;
+}
+
+inline bool containsPoint(const Polygon& polygon, Transform transform, Vec2 point)
+{
+    for (uint8_t i = 0; i < polygon.count; ++i)
+    {
+        const Vec2 v1 = transform.apply(polygon.vertices[i]);
+        const Vec2 normal = transform.rotation.apply(polygon.normals[i]);
+        if (normal.dot(point - v1) > 0.0f)
+            return false;
+    }
+    return true;
+}
+
+// --- Closest point ---
+inline Vec2 closestPoint(const Circle& circle, Transform transform, Vec2 point)
+{
+    const Vec2 center = transform.apply(circle.center);
+    const Vec2 delta = point - center;
+    const float distSqr = delta.lengthSqr();
+    if (distSqr <= circle.radius * circle.radius || distSqr == 0.0f)
+        return point;
+    const float dist = std::sqrt(distSqr);
+    return center + delta * (circle.radius / dist);
+}
+
+inline Vec2 closestPoint(const Capsule& capsule, Transform transform, Vec2 point)
+{
+    const Vec2 worldStart = transform.apply(capsule.center1);
+    const Vec2 worldEnd = transform.apply(capsule.center2);
+    const Vec2 segment = worldEnd - worldStart;
+    const float lengthSqr = segment.lengthSqr();
+    float projection = 0.0f;
+    if (lengthSqr > 0.0f)
+        projection = std::clamp((point - worldStart).dot(segment) / lengthSqr, 0.0f, 1.0f);
+    const Vec2 closestOnSegment = worldStart + segment * projection;
+    const Vec2 delta = point - closestOnSegment;
+    const float distSqr = delta.lengthSqr();
+    if (distSqr <= capsule.radius * capsule.radius || distSqr == 0.0f)
+        return point;
+    const float dist = std::sqrt(distSqr);
+    return closestOnSegment + delta * (capsule.radius / dist);
+}
+
+inline Vec2 closestPoint(const Segment& segment, Transform transform, Vec2 point)
+{
+    const Vec2 worldStart = transform.apply(segment.start);
+    const Vec2 worldEnd = transform.apply(segment.end);
+    const Vec2 edge = worldEnd - worldStart;
+    const float lengthSqr = edge.lengthSqr();
+    if (lengthSqr == 0.0f)
+        return worldStart;
+    const float t = std::clamp((point - worldStart).dot(edge) / lengthSqr, 0.0f, 1.0f);
+    return worldStart + edge * t;
+}
+
+inline Vec2 closestPoint(const Polygon& polygon, Transform transform, Vec2 point)
+{
+    float minDistSqr = std::numeric_limits<float>::max();
+    Vec2 closest{0.0f, 0.0f};
+    bool inside = true;
+    for (uint8_t i = 0; i < polygon.count; ++i)
+    {
+        const Vec2 v1 = transform.apply(polygon.vertices[i]);
+        const Vec2 v2 = transform.apply(polygon.vertices[(i + 1) % polygon.count]);
+        const Vec2 edge = v2 - v1;
+        const float edgeLenSqr = edge.lengthSqr();
+        float t = 0.0f;
+        if (edgeLenSqr > 0.0f)
+            t = std::clamp((point - v1).dot(edge) / edgeLenSqr, 0.0f, 1.0f);
+        const Vec2 candidate = v1 + edge * t;
+        const float distSqr = (point - candidate).lengthSqr();
+        if (distSqr < minDistSqr)
+        {
+            minDistSqr = distSqr;
+            closest = candidate;
+        }
+        const Vec2 normal = transform.rotation.apply(polygon.normals[i]);
+        if (normal.dot(point - v1) > 0.0f)
+            inside = false;
+    }
+    if (inside)
+        return point;
+    return closest;
+}
+
+// --- Minimum distance between shapes ---
+namespace
+{
+template <typename Shape, typename Visitor>
+inline void forEachVertex(const Shape& shape, const Visitor& visitor)
+{
+    for (uint8_t i = 0; i < shape.count; ++i)
+        visitor(shape.vertices[i]);
+}
+
+template <typename Visitor>
+inline void forEachVertex(const Circle& circle, const Visitor& visitor)
+{
+    visitor(circle.center);
+}
+
+template <typename Visitor>
+inline void forEachVertex(const Capsule& capsule, const Visitor& visitor)
+{
+    visitor(capsule.center1);
+    visitor(capsule.center2);
+}
+
+template <typename Visitor>
+inline void forEachVertex(const Segment& segment, const Visitor& visitor)
+{
+    visitor(segment.start);
+    visitor(segment.end);
+}
+} // anonymous namespace
+
+template <typename ShapeA, typename ShapeB>
+inline float distance(const ShapeA& shapeA,
+                      Transform transformA,
+                      const ShapeB& shapeB,
+                      Transform transformB)
+{
+    float bestDistSqr = std::numeric_limits<float>::max();
+
+    auto checkPointA = [&](Vec2 localVertex)
+    {
+        const Vec2 worldPoint = transformA.apply(localVertex);
+        const Vec2 pointOnB = closestPoint(shapeB, transformB, worldPoint);
+        const Vec2 pointOnA = closestPoint(shapeA, transformA, pointOnB);
+        const float distSqr = (pointOnA - pointOnB).lengthSqr();
+        bestDistSqr = std::min(bestDistSqr, distSqr);
+    };
+    forEachVertex(shapeA, checkPointA);
+
+    auto checkPointB = [&](Vec2 localVertex)
+    {
+        const Vec2 worldPoint = transformB.apply(localVertex);
+        const Vec2 pointOnA = closestPoint(shapeA, transformA, worldPoint);
+        const Vec2 pointOnB = closestPoint(shapeB, transformB, pointOnA);
+        const float distSqr = (pointOnA - pointOnB).lengthSqr();
+        bestDistSqr = std::min(bestDistSqr, distSqr);
+    };
+    forEachVertex(shapeB, checkPointB);
+
+    return std::sqrt(bestDistSqr);
+}
+
+
 } // namespace c2d

--- a/tests/geometry/test_ShapeQueries.cpp
+++ b/tests/geometry/test_ShapeQueries.cpp
@@ -1,0 +1,132 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "geometry/ShapesComputations.hpp"
+#include "colli2de/Shapes.hpp"
+
+using namespace c2d;
+using namespace Catch;
+
+TEST_CASE("Point containment for circle", "[ShapeQueries][Contains]")
+{
+    Circle circle{ Vec2{0.0f, 0.0f}, 1.0f };
+    CHECK(containsPoint(circle, Transform{}, Vec2{0.5f, 0.0f}));
+    CHECK_FALSE(containsPoint(circle, Transform{}, Vec2{2.0f, 0.0f}));
+}
+
+TEST_CASE("Point containment for capsule", "[ShapeQueries][Contains]")
+{
+    Capsule capsule{ Vec2{-1.0f, 0.0f}, Vec2{1.0f, 0.0f}, 0.5f };
+    CHECK(containsPoint(capsule, Transform{}, Vec2{0.0f, 0.0f}));
+    CHECK_FALSE(containsPoint(capsule, Transform{}, Vec2{2.0f, 0.0f}));
+}
+
+TEST_CASE("Point containment for segment", "[ShapeQueries][Contains]")
+{
+    Segment seg{ Vec2{0.0f, 0.0f}, Vec2{2.0f, 0.0f} };
+    CHECK(containsPoint(seg, Transform{}, Vec2{1.0f, 0.0f}));
+    CHECK_FALSE(containsPoint(seg, Transform{}, Vec2{1.0f, 0.1f}));
+}
+
+TEST_CASE("Point containment for polygon", "[ShapeQueries][Contains]")
+{
+    Polygon poly = makeRectangle(Vec2{0.0f, 0.0f}, 1.0f, 1.0f);
+    CHECK(containsPoint(poly, Transform{}, Vec2{0.5f, 0.0f}));
+    CHECK_FALSE(containsPoint(poly, Transform{}, Vec2{2.0f, 0.0f}));
+}
+
+TEST_CASE("Closest point on segment", "[ShapeQueries][Closest]")
+{
+    Segment seg{ Vec2{0.0f, 0.0f}, Vec2{2.0f, 0.0f} };
+    const Vec2 result = closestPoint(seg, Transform{}, Vec2{1.0f, 1.0f});
+    CHECK(result == Vec2{1.0f, 0.0f});
+}
+
+TEST_CASE("Distance between circles", "[ShapeQueries][Distance]")
+{
+    Circle a{ Vec2{0.0f, 0.0f}, 1.0f };
+    Circle b{ Vec2{4.0f, 0.0f}, 1.0f };
+    const float dist = distance(a, Transform{}, b, Transform{});
+    CHECK(dist == Approx(2.0f));
+}
+
+TEST_CASE("Distance between circle and capsule", "[ShapeQueries][Distance]")
+{
+    Circle circle{ Vec2{0.0f, 0.0f}, 1.0f };
+    Capsule capsule{ Vec2{4.0f, 0.0f}, Vec2{6.0f, 0.0f}, 0.5f };
+    const float dist = distance(circle, Transform{}, capsule, Transform{});
+    CHECK(dist == Approx(2.5f));
+}
+
+TEST_CASE("Distance between circle and segment", "[ShapeQueries][Distance]")
+{
+    Circle circle{ Vec2{0.0f, 0.0f}, 1.0f };
+    Segment seg{ Vec2{4.0f, 0.0f}, Vec2{6.0f, 0.0f} };
+    const float dist = distance(circle, Transform{}, seg, Transform{});
+    CHECK(dist == Approx(3.0f));
+}
+
+TEST_CASE("Distance between circle and polygon", "[ShapeQueries][Distance]")
+{
+    Circle circle{ Vec2{0.0f, 0.0f}, 1.0f };
+    Polygon poly = makeRectangle(Vec2{4.0f, 0.0f}, 1.0f, 1.0f);
+    const float dist = distance(circle, Transform{}, poly, Transform{});
+    CHECK(dist == Approx(2.0f));
+}
+
+TEST_CASE("Distance between capsules", "[ShapeQueries][Distance]")
+{
+    Capsule a{ Vec2{0.0f, 0.0f}, Vec2{2.0f, 0.0f}, 0.5f };
+    Capsule b{ Vec2{4.0f, 0.0f}, Vec2{6.0f, 0.0f}, 0.5f };
+    const float dist = distance(a, Transform{}, b, Transform{});
+    CHECK(dist == Approx(1.0f));
+}
+
+TEST_CASE("Distance between capsule and segment", "[ShapeQueries][Distance]")
+{
+    Capsule capsule{ Vec2{0.0f, 0.0f}, Vec2{2.0f, 0.0f}, 0.5f };
+    Segment seg{ Vec2{4.0f, 0.0f}, Vec2{6.0f, 0.0f} };
+    const float dist = distance(capsule, Transform{}, seg, Transform{});
+    CHECK(dist == Approx(1.5f));
+}
+
+TEST_CASE("Distance between capsule and polygon", "[ShapeQueries][Distance]")
+{
+    Capsule capsule{ Vec2{0.0f, 0.0f}, Vec2{2.0f, 0.0f}, 0.5f };
+    Polygon poly = makeRectangle(Vec2{4.5f, 0.0f}, 1.0f, 1.0f);
+    const float dist = distance(capsule, Transform{}, poly, Transform{});
+    CHECK(dist == Approx(1.0f));
+}
+
+TEST_CASE("Distance between segments", "[ShapeQueries][Distance]")
+{
+    Segment a{ Vec2{0.0f, 0.0f}, Vec2{2.0f, 0.0f} };
+    Segment b{ Vec2{4.0f, 0.0f}, Vec2{6.0f, 0.0f} };
+    const float dist = distance(a, Transform{}, b, Transform{});
+    CHECK(dist == Approx(2.0f));
+}
+
+TEST_CASE("Distance between segment and polygon", "[ShapeQueries][Distance]")
+{
+    Segment seg{ Vec2{0.0f, 0.0f}, Vec2{2.0f, 0.0f} };
+    Polygon poly = makeRectangle(Vec2{4.5f, 0.0f}, 1.0f, 1.0f);
+    const float dist = distance(seg, Transform{}, poly, Transform{});
+    CHECK(dist == Approx(1.5f));
+}
+
+TEST_CASE("Distance between polygons", "[ShapeQueries][Distance]")
+{
+    Polygon a = makeRectangle(Vec2{0.0f, 0.0f}, 1.0f, 1.0f);
+    Polygon b = makeRectangle(Vec2{3.0f, 0.0f}, 1.0f, 1.0f);
+    const float dist = distance(a, Transform{}, b, Transform{});
+    CHECK(dist == Approx(1.0f));
+}
+
+TEST_CASE("Distance between circle and rectangle", "[ShapeQueries][Distance]")
+{
+    Circle c{ Vec2{0.0f, 0.0f}, 0.5f };
+    Polygon poly = makeRectangle(Vec2{3.0f, 0.0f}, 1.0f, 1.0f);
+    const float dist = distance(c, Transform{}, poly, Transform{});
+    CHECK(dist == Approx(1.5f));
+}
+


### PR DESCRIPTION
## Summary
- implement containment, closest point, and distance utilities for shapes
- add tests covering shape query operations
- encapsulate `forEachVertex` in an anonymous namespace
- extend unit tests to verify containment for all shapes and distances between every pair
- fix test include for shape utilities

## Testing
- `./test.sh --cmake -b -r "~[Benchmark]"`

------
https://chatgpt.com/codex/tasks/task_e_6861a3c69cd8832882e0d6fae7713c15